### PR TITLE
[#14] Throw authentication errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "dotenv": "^16.4.5",
+    "graphql": "^16.8.1",
     "graphql-parse-resolve-info": "^4.13.0",
     "mysql2": "^3.9.2",
     "passport": "^0.7.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -32,18 +32,12 @@ import { UserModule } from './user/user.module';
       driver: ApolloDriver,
       autoSchemaFile: true,
       sortSchema: true,
-      formatError: (error) => {
-        const errorMessage = error.message;
-        let code = error.extensions?.code;
-        if (error.extensions?.status === 404) code = 'RESOURCE_NOT_FOUND';
-        if (errorMessage.includes('Invalid payload:'))
-          code = 'GRAPHQL_VALIDATION_FAILED';
-
-        return {
-          code,
-          message: error.message,
-        };
-      },
+      formatError: (error) => ({
+        message: error.message,
+        extensions: {
+          code: error.extensions.code,
+        },
+      }),
     }),
     SequelizeModule.forRoot({
       dialect: process.env.DATABASE_TYPE,

--- a/src/auth/guards/jwt-auth.guard.ts
+++ b/src/auth/guards/jwt-auth.guard.ts
@@ -1,11 +1,32 @@
-import { ExecutionContext, Injectable } from '@nestjs/common';
+import {
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { GqlExecutionContext } from '@nestjs/graphql';
+import { TokenExpiredError } from '@nestjs/jwt';
 import { AuthGuard } from '@nestjs/passport';
+import { User } from 'src/user/entities/user.entity';
 
 @Injectable()
 export class JwtAuthGuard extends AuthGuard('jwt') {
   getRequest(context: ExecutionContext) {
     const ctx = GqlExecutionContext.create(context);
     return ctx.getContext().req;
+  }
+
+  handleRequest<TUser = Pick<User, 'id' | 'email'>>(
+    err: any,
+    user: TUser,
+    info: any,
+  ): TUser {
+    if (info instanceof TokenExpiredError) {
+      throw new UnauthorizedException('TOKEN_EXPIRED');
+    }
+
+    if (err || !user) {
+      throw err || new UnauthorizedException();
+    }
+    return user;
   }
 }

--- a/src/auth/guards/jwt-auth.guard.ts
+++ b/src/auth/guards/jwt-auth.guard.ts
@@ -1,8 +1,5 @@
-import {
-  ExecutionContext,
-  Injectable,
-  UnauthorizedException,
-} from '@nestjs/common';
+import { AuthenticationError } from '@nestjs/apollo';
+import { ExecutionContext, Injectable } from '@nestjs/common';
 import { GqlExecutionContext } from '@nestjs/graphql';
 import { TokenExpiredError } from '@nestjs/jwt';
 import { AuthGuard } from '@nestjs/passport';
@@ -21,11 +18,15 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
     info: any,
   ): TUser {
     if (info instanceof TokenExpiredError) {
-      throw new UnauthorizedException('TOKEN_EXPIRED');
+      throw new AuthenticationError(info.message, {
+        extensions: {
+          code: 'TOKEN_EXPIRED',
+        },
+      });
     }
 
     if (err || !user) {
-      throw err || new UnauthorizedException();
+      throw err || new AuthenticationError('UNAUTHORIZED');
     }
     return user;
   }

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -1,5 +1,6 @@
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
+import { User } from 'src/user/entities/user.entity';
 
 export class JwtStrategy extends PassportStrategy(Strategy) {
   constructor() {
@@ -10,7 +11,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  async validate(payload: any) {
+  validate(payload: any): Pick<User, 'id' | 'email'> {
     return {
       id: payload.sub,
       email: payload.email,

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,9 +5,11 @@ import {
 } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { HttpErrorFilter } from './common/filters/http-error.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useGlobalFilters(new HttpErrorFilter());
   app.useGlobalPipes(
     new ValidationPipe({
       exceptionFactory: (errors: ValidationError[]) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,11 +5,9 @@ import {
 } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
-import { HttpErrorFilter } from './common/filters/http-error.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  app.useGlobalFilters(new HttpErrorFilter());
   app.useGlobalPipes(
     new ValidationPipe({
       exceptionFactory: (errors: ValidationError[]) => {


### PR DESCRIPTION
- When an access token is expired, we now throw an error with a `TOKEN_EXPIRED` code.
- I also did some refactoring around the unauthorized error thrown so it matches graphQL errors