### PR TITLE
[#17] Throw GraphQL errors instead of NestJS HTTP errors

### DIFF
--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,4 +1,4 @@
-import { NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { AuthenticationError, ForbiddenError } from '@nestjs/apollo';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -75,7 +75,7 @@ describe('AuthService', () => {
       const email = 'test@test.com';
 
       await expect(service.validateUser(email, password)).rejects.toThrow(
-        UnauthorizedException,
+        AuthenticationError,
       );
     });
 
@@ -84,7 +84,7 @@ describe('AuthService', () => {
       const email = 'hackerman@test.com';
 
       await expect(service.validateUser(email, password)).rejects.toThrow(
-        NotFoundException,
+        AuthenticationError,
       );
     });
   });
@@ -122,9 +122,7 @@ describe('AuthService', () => {
         lastname: 'user',
       };
 
-      await expect(service.register(args)).rejects.toThrow(
-        UnauthorizedException,
-      );
+      await expect(service.register(args)).rejects.toThrow(ForbiddenError);
     });
   });
 
@@ -149,7 +147,7 @@ describe('AuthService', () => {
         email,
       };
 
-      await expect(service.login(user)).rejects.toThrow(NotFoundException);
+      await expect(service.login(user)).rejects.toThrow(AuthenticationError);
     });
   });
 
@@ -174,18 +172,18 @@ describe('AuthService', () => {
         email,
       };
 
-      await expect(service.login(user)).rejects.toThrow(NotFoundException);
+      await expect(service.login(user)).rejects.toThrow(AuthenticationError);
     });
 
     it('should throw an error if the user is invalid.', async () => {
       let user: AuthUser = {} as AuthUser;
 
-      await expect(service.login(user)).rejects.toThrow(UnauthorizedException);
+      await expect(service.login(user)).rejects.toThrow(AuthenticationError);
 
       user = {
         email: null,
       } as AuthUser;
-      await expect(service.login(user)).rejects.toThrow(UnauthorizedException);
+      await expect(service.login(user)).rejects.toThrow(AuthenticationError);
     });
   });
 

--- a/src/auth/strategies/local.strategy.ts
+++ b/src/auth/strategies/local.strategy.ts
@@ -1,4 +1,4 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { Strategy } from 'passport-local';
 import { AuthService } from '../auth.service';
@@ -10,10 +10,6 @@ export class LocalStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(email: string, password: string) {
-    const user = this.authService.validateUser(email, password);
-    if (!user) {
-      throw new UnauthorizedException();
-    }
-    return user;
+    return this.authService.validateUser(email, password);
   }
 }

--- a/src/class/class.resolver.spec.ts
+++ b/src/class/class.resolver.spec.ts
@@ -1,8 +1,8 @@
-import { NotFoundException } from '@nestjs/common';
 import { getModelToken } from '@nestjs/sequelize';
 import { Test, TestingModule } from '@nestjs/testing';
 import { CardService } from 'src/card/card.service';
 import { Card } from 'src/card/entities/card.entity';
+import { ResourceNotFoundError } from 'src/common/errors/resource-not-found.error';
 import CardModelFactory from 'src/common/test-utils/card.model.factory';
 import ClassModelFactory from 'src/common/test-utils/class.model.factory';
 import { ClassResolver } from './class.resolver';
@@ -51,7 +51,7 @@ describe('ClassResolver', () => {
       const t = async () => {
         await resolver.findOne(classId, { fields: ['id'], relations: {} });
       };
-      expect(t).rejects.toThrow(NotFoundException);
+      expect(t).rejects.toThrow(ResourceNotFoundError);
     });
   });
 

--- a/src/class/class.resolver.ts
+++ b/src/class/class.resolver.ts
@@ -1,8 +1,8 @@
-import { NotFoundException } from '@nestjs/common';
 import { Args, Int, Query, Resolver } from '@nestjs/graphql';
 import { CardService } from 'src/card/card.service';
 import { Card } from 'src/card/entities/card.entity';
 import { Fields, ParsedField } from 'src/common/decorators/fields.decorator';
+import { ResourceNotFoundError } from 'src/common/errors/resource-not-found.error';
 import { ClassService } from './class.service';
 import { FindAllClassesArgs } from './dto/find-all-classes.args';
 import { FindOneClassArgs } from './dto/find-one-class.args';
@@ -29,7 +29,7 @@ export class ClassResolver {
     args.id = id;
     const clax = await this.classService.findOne(args);
     if (!clax) {
-      throw new NotFoundException(id);
+      throw new ResourceNotFoundError(`Could not find class with id ${id}.`);
     }
     return clax;
   }

--- a/src/common/errors/resource-not-found.error.ts
+++ b/src/common/errors/resource-not-found.error.ts
@@ -2,6 +2,11 @@ import { GraphQLError, GraphQLErrorOptions } from 'graphql';
 
 export class ResourceNotFoundError extends GraphQLError {
   constructor(message: string, options?: GraphQLErrorOptions) {
+    if (!options) {
+      options = {
+        extensions: {},
+      };
+    }
     options.extensions.code = 'RESOURCE_NOT_FOUND';
     super(message, options);
   }

--- a/src/common/errors/resource-not-found.error.ts
+++ b/src/common/errors/resource-not-found.error.ts
@@ -1,0 +1,8 @@
+import { GraphQLError, GraphQLErrorOptions } from 'graphql';
+
+export class ResourceNotFoundError extends GraphQLError {
+  constructor(message: string, options?: GraphQLErrorOptions) {
+    options.extensions.code = 'RESOURCE_NOT_FOUND';
+    super(message, options);
+  }
+}

--- a/src/common/filters/http-error.filter.ts
+++ b/src/common/filters/http-error.filter.ts
@@ -1,0 +1,27 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+} from '@nestjs/common';
+import { GraphQLError } from 'graphql';
+
+@Catch(HttpException)
+export class HttpErrorFilter implements ExceptionFilter {
+  catch(exception: HttpException, host: ArgumentsHost) {
+    switch (host.getType() as string) {
+      case 'http':
+        const response = host.switchToHttp().getResponse();
+        response.status(exception.getStatus()).json({
+          message: exception.message,
+        });
+        break;
+      case 'graphql':
+        return new GraphQLError(exception.message, {
+          extensions: {
+            code: exception.name,
+          },
+        });
+    }
+  }
+}

--- a/src/deck/deck.service.spec.ts
+++ b/src/deck/deck.service.spec.ts
@@ -1,6 +1,6 @@
-import { NotFoundException } from '@nestjs/common';
 import { getModelToken } from '@nestjs/sequelize';
 import { Test, TestingModule } from '@nestjs/testing';
+import { ResourceNotFoundError } from 'src/common/errors/resource-not-found.error';
 import DeckCardModelFactory from 'src/common/test-utils/deck-card.model.factory';
 import DeckModelFactory from 'src/common/test-utils/deck.model.factory';
 import { DeckService } from './deck.service';
@@ -136,7 +136,7 @@ describe('DeckService', () => {
           attributes,
           id: 1,
         }),
-      ).rejects.toThrow(NotFoundException);
+      ).rejects.toThrow(ResourceNotFoundError);
     });
   });
 

--- a/src/deck/deck.service.ts
+++ b/src/deck/deck.service.ts
@@ -1,10 +1,11 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/sequelize';
 import { Includeable, Op, Sequelize, WhereOptions } from 'sequelize';
 import { Card } from 'src/card/entities/card.entity';
 import { Class } from 'src/class/entities/class.entity';
 import { CursorService } from 'src/common/cursor.service';
 import { ParsedField } from 'src/common/decorators/fields.decorator';
+import { ResourceNotFoundError } from 'src/common/errors/resource-not-found.error';
 import { IEdgeType } from 'src/common/interfaces/paginated.interface';
 import { Rarity } from 'src/rarity/entities/rarity.entity';
 import { CreateDeckInput } from './dto/create-deck.input';
@@ -112,7 +113,7 @@ export class DeckService {
     });
 
     if (!deck) {
-      throw new NotFoundException(`Could not find deck with id ${id}.`);
+      throw new ResourceNotFoundError(`Could not find deck with id ${id}.`);
     }
 
     return deck;

--- a/src/deck/pipes/deck-validation.pipe.spec.ts
+++ b/src/deck/pipes/deck-validation.pipe.spec.ts
@@ -1,4 +1,4 @@
-import { UnprocessableEntityException } from '@nestjs/common';
+import { UserInputError } from '@nestjs/apollo';
 import { getModelToken } from '@nestjs/sequelize';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Card, CardType } from 'src/card/entities/card.entity';
@@ -124,7 +124,7 @@ describe('DeckValidationPipe', () => {
 
       await expect(
         pipe.transform({ format, name, deckCards, userId }),
-      ).rejects.toThrow(UnprocessableEntityException);
+      ).rejects.toThrow(UserInputError);
     });
   });
 });

--- a/src/deck/pipes/deck-validation.pipe.ts
+++ b/src/deck/pipes/deck-validation.pipe.ts
@@ -1,8 +1,5 @@
-import {
-  Injectable,
-  PipeTransform,
-  UnprocessableEntityException,
-} from '@nestjs/common';
+import { UserInputError } from '@nestjs/apollo';
+import { Injectable, PipeTransform } from '@nestjs/common';
 import { InjectModel } from '@nestjs/sequelize';
 import { Card } from 'src/card/entities/card.entity';
 import { Class } from 'src/class/entities/class.entity';
@@ -71,6 +68,6 @@ export class DeckValidationPipe
   }
 
   private sendValidationError(err: string) {
-    throw new UnprocessableEntityException(`Invalid payload: ${err}`);
+    throw new UserInputError(err);
   }
 }

--- a/src/expansion/expansion.resolver.spec.ts
+++ b/src/expansion/expansion.resolver.spec.ts
@@ -1,6 +1,6 @@
-import { NotFoundException } from '@nestjs/common';
 import { getModelToken } from '@nestjs/sequelize';
 import { Test, TestingModule } from '@nestjs/testing';
+import { ResourceNotFoundError } from 'src/common/errors/resource-not-found.error';
 import expansionModelFactory from 'src/common/test-utils/expansion.model.factory';
 import { FindAllExpansionsArgs } from './dto/find-all-expansions.args';
 import { Expansion } from './entities/expansion.entity';
@@ -63,7 +63,7 @@ describe('ExpansionResolver', () => {
       const t = async () => {
         await resolver.findOne(expansionId);
       };
-      expect(t).rejects.toThrow(NotFoundException);
+      expect(t).rejects.toThrow(ResourceNotFoundError);
     });
   });
 });

--- a/src/expansion/expansion.resolver.ts
+++ b/src/expansion/expansion.resolver.ts
@@ -1,6 +1,6 @@
-import { NotFoundException } from '@nestjs/common';
 import { Args, Int, Query, Resolver } from '@nestjs/graphql';
 import { Fields, ParsedField } from 'src/common/decorators/fields.decorator';
+import { ResourceNotFoundError } from 'src/common/errors/resource-not-found.error';
 import { FindAllExpansionsArgs } from './dto/find-all-expansions.args';
 import { Expansion } from './entities/expansion.entity';
 import { PaginatedExpansions } from './entities/paginated-expansions.entity';
@@ -26,7 +26,9 @@ export class ExpansionResolver {
   async findOne(@Args('id', { type: () => Int }) id: number) {
     const expansion = await this.expansionService.findOne(id);
     if (!expansion) {
-      throw new NotFoundException(id);
+      throw new ResourceNotFoundError(
+        `Could not find expansion with id ${id}.`,
+      );
     }
     return expansion;
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,5 @@
-import {
-  UnprocessableEntityException,
-  ValidationError,
-  ValidationPipe,
-} from '@nestjs/common';
+import { UserInputError } from '@nestjs/apollo';
+import { ValidationError, ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { HttpErrorFilter } from './common/filters/http-error.filter';
@@ -16,7 +13,7 @@ async function bootstrap() {
         const errorMessages = errors.map((error) =>
           Object.values(error.constraints),
         );
-        return new UnprocessableEntityException(
+        return new UserInputError(
           `Invalid payload: ${errorMessages.join(',')}`,
         );
       },

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,9 +5,11 @@ import {
 } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { HttpErrorFilter } from './common/filters/http-error.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useGlobalFilters(new HttpErrorFilter());
   app.useGlobalPipes(
     new ValidationPipe({
       exceptionFactory: (errors: ValidationError[]) => {


### PR DESCRIPTION
NestJS API errors are great but not ideal for graphQL APIs. This is because GraphQL doesn't throw HTTP errors so we had to map those errors in the apollo client instance which wasn't ideal.

This was also problematic in the front end, as most FE packages expect errors to follow a specific format. So instead we're now only throwing graphQL.